### PR TITLE
poetry uses ulsdk v0.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.poetry]
 name = "ulsdk"
-version = "0.3.1"
+version = "0.4.0"
 description = "A Python SDK for the UrbanLogiq API"
 authors = ["UrbanLogiq <customersuccess@urbanlogiq.com>"]
 


### PR DESCRIPTION
The `ulsdk/pyproject.toml` file contains two different versions:

- [project] section: version = `0.4.0`
- [tool.poetry] section: version = `0.3.1`

The Rust package (ulsdk/rust/ulsdk/Cargo.toml) uses version `0.4.0`, however Python (which relies on Poetry) used version `0.3.1`. This PR points poetry to use version `0.4.0` for consistency.